### PR TITLE
Fix to autoload calle24-install and calle24-uninstall

### DIFF
--- a/lisp/calle24.el
+++ b/lisp/calle24.el
@@ -308,6 +308,7 @@ default:
      ((string= appearance "light") (calle24-light-appearance))
      (t (calle24-light-appearance)))))
 
+;;;###autoload (autoload 'calle24-install "calle24" nil t)
 (defun calle24-install ()
   "Install Calle 24 tool bar images.
 
@@ -353,6 +354,7 @@ directory for Calle 24 images `calle24-image-directory'."
           (push image-directory iload-path)
           (customize-save-variable 'image-load-path iload-path)))))
 
+;;;###autoload (autoload 'calle24-uninstall "calle24" nil t)
 (defun calle24-uninstall ()
   "Uninstall Calle 24 from this system.
 


### PR DESCRIPTION
- Add autoload cookie for calle24-install and calle24-uninstall commands.
