### PR TITLE
Merge development to main 20250311_084615

### DIFF
--- a/lisp/calle24.el
+++ b/lisp/calle24.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/calle24
 ;; Keywords: tools
-;; Version: 1.0.5
+;; Version: 1.0.6-rc.1
 ;; Package-Requires: ((emacs "29.1"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Bump version to 1.0.6-rc.1**
  

- **Fix to autoload calle24-install and calle24-uninstall**
  - Add autoload cookie for calle24-install and calle24-uninstall commands.
  