### PR TITLE
Merge development to main 20250506_200141

### DIFF
--- a/lisp/calle24.el
+++ b/lisp/calle24.el
@@ -5,7 +5,7 @@
 ;; Author: Charles Choi <kickingvegas@gmail.com>
 ;; URL: https://github.com/kickingvegas/calle24
 ;; Keywords: tools
-;; Version: 1.0.8
+;; Version: 1.0.9-rc.1
 ;; Package-Requires: ((emacs "29.1"))
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
- **Bump version to 1.0.9-rc.1**
  

- **Ensure doc-view-tool-bar-map is bound before use.**
  In my Emacs (29.4) doc-view-tool-bar-map is unbound, causing an error
  on attempts change between light and dark appearance.
  